### PR TITLE
@lightclient + @anna-carroll reviews

### DIFF
--- a/crates/interpreter/src/gas/calc.rs
+++ b/crates/interpreter/src/gas/calc.rs
@@ -315,7 +315,12 @@ fn xfer_cost(is_call_or_callcode: bool, transfers_value: bool, is_authcall: bool
 }
 
 #[inline]
-fn new_cost<SPEC: Spec>(is_call_or_staticcall: bool, is_new: bool, transfers_value: bool, is_authcall: bool) -> u64 {
+fn new_cost<SPEC: Spec>(
+    is_call_or_staticcall: bool,
+    is_new: bool,
+    transfers_value: bool,
+    is_authcall: bool,
+) -> u64 {
     if is_call_or_staticcall || is_authcall {
         // EIP-161: State trie clearing (invariant-preserving alternative)
         if SPEC::enabled(SPURIOUS_DRAGON) {

--- a/crates/interpreter/src/instruction_result.rs
+++ b/crates/interpreter/src/instruction_result.rs
@@ -24,7 +24,7 @@ pub enum InstructionResult {
     OpcodeNotFound,
     CallNotAllowedInsideStatic,
     StateChangeDuringStaticCall,
-    ActiveAccountUnsetAuthCall,
+    UnauthorizedAuthCall,
     InvalidFEOpcode,
     InvalidJump,
     NotActivated,
@@ -170,9 +170,7 @@ impl From<InstructionResult> for SuccessOrHalt {
             InstructionResult::StateChangeDuringStaticCall => {
                 Self::Halt(Halt::StateChangeDuringStaticCall)
             }
-            InstructionResult::ActiveAccountUnsetAuthCall => {
-                Self::Halt(Halt::ActiveAccountUnsetAuthCall)
-            }
+            InstructionResult::UnauthorizedAuthCall => Self::Halt(Halt::UnauthorizedAuthCall),
             InstructionResult::InvalidFEOpcode => Self::Halt(Halt::InvalidFEOpcode),
             InstructionResult::InvalidJump => Self::Halt(Halt::InvalidJump),
             InstructionResult::NotActivated => Self::Halt(Halt::NotActivated),

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -363,7 +363,7 @@ pub enum Halt {
     /* Internal Halts that can be only found inside Inspector */
     OverflowPayment,
     StateChangeDuringStaticCall,
-    ActiveAccountUnsetAuthCall,
+    UnauthorizedAuthCall,
     CallNotAllowedInsideStatic,
     OutOfFund,
     CallTooDeep,


### PR DESCRIPTION
## Overview

Addresses some review comments from #1 

- [x] Rename `ActiveAccountUnsetAuthCall` error -> `UnauthorizedAuthCall`
- [x] Fix panic case on `AUTH`; At a minimum, the opcode should expand memory to `offset + 97` if it is not already allocated. More expansion can occur if `length` > `97` and the memory is not already allocated.
- [x] Fix divergence from spec in `AUTH`: "If the signature is instead invalid or the signer address does not equal `authority`, `authorized` is reset to an unset value."